### PR TITLE
test: mutation-harden LibBytecode source-offset boundary coverage

### DIFF
--- a/test/src/lib/bytecode/LibBytecode.checkNoOOBPointers.t.sol
+++ b/test/src/lib/bytecode/LibBytecode.checkNoOOBPointers.t.sol
@@ -385,4 +385,42 @@ contract LibBytecodeCheckNoOOBPointersTest is BytecodeTest {
         vm.expectRevert(abi.encodeWithSelector(StackSizingsNotMonotonic.selector, bytecode, offset));
         this.checkNoOOBPointersExternal(bytecode);
     }
+
+    /// Boundary: when the bytecode length is exactly `1 + sourceCount * 2`, the
+    /// offset pointer table fills the bytecode with zero room for any source
+    /// header. The offset-table bounds check `sourcesRelativeStart >
+    /// bytecode.length` is `false` at this exact length (it only fires when the
+    /// offsets themselves are truncated), so execution proceeds and the missing
+    /// 4 byte header is caught downstream as `TruncatedHeader` rather than
+    /// `TruncatedHeaderOffsets`. This pins the `>` boundary: a `>=` guard would
+    /// short-circuit here and revert with `TruncatedHeaderOffsets` instead.
+    function testCheckNoOOBPointersOffsetsExactNoHeaderRoomCount1() external {
+        // count = 1, sourcesRelativeStart = 1 + 1 * 2 = 3, length = 3.
+        // [01][offset_hi=00][offset_lo=00]
+        bytes memory bytecode = hex"010000";
+        vm.expectRevert(abi.encodeWithSelector(TruncatedHeader.selector, bytecode));
+        this.checkNoOOBPointersExternal(bytecode);
+    }
+
+    /// As above with count = 2: sourcesRelativeStart = 1 + 2 * 2 = 5, length 5.
+    /// [02][off0_hi=00][off0_lo=00][off1_hi=00][off1_lo=00]
+    function testCheckNoOOBPointersOffsetsExactNoHeaderRoomCount2() external {
+        bytes memory bytecode = hex"0200000000";
+        vm.expectRevert(abi.encodeWithSelector(TruncatedHeader.selector, bytecode));
+        this.checkNoOOBPointersExternal(bytecode);
+    }
+
+    /// Fuzz the boundary across all valid source counts. A bytecode that is
+    /// exactly the count byte plus `count * 2` zeroed offset bytes (and nothing
+    /// else) MUST revert with `TruncatedHeader`, never `TruncatedHeaderOffsets`.
+    function testCheckNoOOBPointersOffsetsExactNoHeaderRoomFuzz(uint8 sourceCount) external {
+        sourceCount = uint8(bound(sourceCount, 1, type(uint8).max));
+        // 1 count byte + 2 bytes per source offset, no source headers.
+        bytes memory bytecode = new bytes(1 + uint256(sourceCount) * 2);
+        bytecode[0] = bytes1(sourceCount);
+        // All offset bytes remain zero, which is well-formed for the offset
+        // table (the first offset must be zero) but leaves no header room.
+        vm.expectRevert(abi.encodeWithSelector(TruncatedHeader.selector, bytecode));
+        this.checkNoOOBPointersExternal(bytecode);
+    }
 }

--- a/test/src/lib/bytecode/LibBytecode.sourceRelativeOffset.t.sol
+++ b/test/src/lib/bytecode/LibBytecode.sourceRelativeOffset.t.sol
@@ -77,4 +77,34 @@ contract LibBytecodeSourceRelativeOffsetTest is BytecodeTest {
             LibBytecodeSlow.sourceRelativeOffsetSlow(bytecode, sourceIndex)
         );
     }
+
+    /// The relative offset is a 16 bit big-endian value, so its high byte is
+    /// load-bearing. These cases pin offsets that do not fit in a single byte
+    /// (>= 0x100). A mask that dropped the high byte would read a different,
+    /// smaller offset. `sourceRelativeOffset` does not validate that the offset
+    /// points anywhere real (that is `checkNoOOBPointers`' job), so the offset
+    /// bytes can be set directly without a conforming body.
+    function testSourceRelativeOffsetHighByte() external pure {
+        // count = 2, source 0 offset 0x0000, source 1 offset 0x0102 (258).
+        assertEq(LibBytecode.sourceRelativeOffset(hex"0200000102", 1), 0x0102);
+        // count = 1, source 0 offset 0xFF00 (65280): the value lives entirely
+        // in the high byte, so dropping it would read 0.
+        assertEq(LibBytecode.sourceRelativeOffset(hex"01FF00", 0), 0xFF00);
+        // count = 1, source 0 offset 0xFFFF (65535): full 16 bits set.
+        assertEq(LibBytecode.sourceRelativeOffset(hex"01FFFF", 0), 0xFFFF);
+    }
+
+    /// Reference cross-check for high (>= 0x100) offsets. The slow
+    /// implementation independently reads both offset bytes, so it diverges
+    /// from any production read that drops the high byte.
+    function testSourceRelativeOffsetHighByteReference(uint16 offset) external pure {
+        vm.assume(offset >= 0x100);
+        // count = 1, single offset taken from the fuzzed high value.
+        bytes memory bytecode = new bytes(3);
+        bytecode[0] = bytes1(uint8(1));
+        bytecode[1] = bytes1(uint8(offset >> 8));
+        bytecode[2] = bytes1(uint8(offset));
+        assertEq(LibBytecode.sourceRelativeOffset(bytecode, 0), offset);
+        assertEq(LibBytecode.sourceRelativeOffset(bytecode, 0), LibBytecodeSlow.sourceRelativeOffsetSlow(bytecode, 0));
+    }
 }


### PR DESCRIPTION
## Summary

Scoped adversarial mutation-testing pass over `LibBytecode`. The existing test suite is already strong (every reader function has a `LibBytecodeSlow` differential fuzz + concrete examples; `checkNoOOBPointers` corruption-tests every revert path). A mutation battery nonetheless surfaced **two genuinely surviving mutants**, both around the 16-bit source relative offset. This PR adds discriminating tests that kill them. **Tests only — `git diff src/` is empty.**

## Module hardened: `src/lib/bytecode/LibBytecode.sol`

### Mutation matrix

| # | Location | Mutation | Before | After |
|---|----------|----------|--------|-------|
| C8 | `checkNoOOBPointers` offset-table guard | `sourcesRelativeStart > bytecode.length` → `>=` | **SURVIVED** | KILLED |
| S4 | `sourceRelativeOffset` offset read | `and(mload(...), 0xFFFF)` → `0xFF` | **SURVIVED** | KILLED |
| C1 | `checkNoOOBPointers` | `headerEnd = absoluteOffset + 4` → `+3` | killed | — |
| C2 | `checkNoOOBPointers` | header `>` → `>=` | killed | — |
| C3 | `checkNoOOBPointers` | `opsCount * 4` → `*3` | killed | — |
| C4 | `checkNoOOBPointers` | `sourceEnd != endCursor` → `>` | killed | — |
| C5 | `checkNoOOBPointers` | `inputs > outputs` → `>=` | killed | — |
| C6 | `checkNoOOBPointers` | `outputs > stackAllocation` → `>=` | killed | — |
| C7 | `checkNoOOBPointers` | `1 + count * 2` → `* 3` | killed | — |
| C9 | `checkNoOOBPointers` | trailing `length > 1` → `> 2` | killed | — |
| C10 | `checkNoOOBPointers` | `endCursor != sourcesStart` → `>` | equivalent (`endCursor >= sourcesStart` always) | — |
| S1 | `sourceCount` | `length == 0` → `<= 1` | killed | — |
| S2/S3 | `sourceRelativeOffset` | base `+3`→`+2`, stride `*2`→`*3` | killed | — |
| S5 | `sourcePointer` | `1 + count * 2` → `* 3` | killed | — |
| S6/S7/S8 | `sourceOpsCount`/`StackAllocation`/`InputsOutputs` | header byte index shifts | killed | — |
| shuffle | `bytecodeToSources` | opcode-shuffle byte moves | killed | — |

### The two real gaps

**C8 — offset-table boundary.** No test exercised `bytecode.length == 1 + sourceCount * 2` exactly: the offset pointer table fills the bytecode with zero room for any source header. The `>` guard correctly lets this proceed and revert downstream as `TruncatedHeader`; a `>=` mutant short-circuits to `TruncatedHeaderOffsets`. Added concrete count=1 / count=2 plus a fuzz-over-count test pinning `TruncatedHeader` at this length.

**S4 — 16-bit offset high byte.** The relative offset is a 2-byte big-endian value, but every prior test (concrete + differential fuzz over `conformBytecode`) only produced offsets ≤ `0xFF`, so the high byte was never load-bearing. Dropping it (`0xFF` mask) survived. Added concrete (`0x0102`, `0xFF00`, `0xFFFF`) and a fuzzed high-offset (`>= 0x100`) `LibBytecodeSlow` cross-check.

Each new test passes on baseline and fails under its target mutant (verified by re-applying the mutant).

## Build / test

- `forge build`: clean (0 errors)
- `forge fmt --check`: clean
- Full suite: **115 passed, 0 failed, 0 skipped** (was 110; +5 new tests)
- `git diff src/`: empty (tests only)

## Remaining gaps (out of scope)

- [ ] `LibParseMeta.lookupWord` / `checkParseMetaStructure` — deliberately untouched (covered by in-flight PRs #109 / rainlang #534).
- [ ] All other `LibBytecode`, `LibContext`, `LibEvaluable`, `LibNamespace`, `LibGenParseMeta`, `LibParseMeta.wordBitmapped` behaviors probed in the matrix were already mutation-tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added boundary condition tests for bytecode offset validation to ensure proper error handling at exact-length scenarios with various source counts.
  * Added test coverage for high-byte offset scenarios in relative offset calculations, including fuzz testing with reference validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->