### PR TITLE
chore(release): bump [package].version to 0.1.3 for next-version Soldeer lifecycle

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rain-interpreter-interface"
-version = "0.1.2"
+version = "0.1.3"
 
 [profile.default]
 


### PR DESCRIPTION
Closes #112

## What

One-time `foundry.toml` `[package].version` bump `0.1.2` → `0.1.3` to adopt the next-version Soldeer release lifecycle (the shared `rainix-autopublish` reusable switched from auto-bump to next-version in rainlanguage/rainix#264; this repo's `package-release.yaml` already pins the reusable `@main`, so the new behaviour is live).

The declared in-dev version must be **strictly ahead** of the latest published revision. It was `0.1.2`, equal to the latest published `rain-interpreter-interface` revision `0.1.2`, so the next Solidity-content merge would fail the autopublish gate (`version (0.1.2) is not ahead of the published revision (0.1.2)`). Bumping to `0.1.3` (the next unpublished patch) fixes that; the lifecycle self-maintains thereafter.

This is a pure interface/library repo — there are **no** version-keyed generated artifacts (`src/generated/` does not exist), so per the issue no `soldeer-generate-cmd` wiring is needed; the version bump is the whole fix.

## QA evidence (config-only change — no executable/behavioral surface)

This diff changes a single TOML version string; there is no Solidity/Rust/TS logic in the change, so adversarial mutation testing is category-N/A (nothing to mutate). Verification is the concrete facts the change depends on:

- **Version-vs-registry oracle:** the latest published `rain-interpreter-interface` Soldeer revision is `0.1.2`; `foundry.toml` was `0.1.2` (equal, not ahead), so `0.1.3` is the correct next unpublished patch. A wrong bump (leaving `0.1.2`, or jumping to `0.2.0`) is discriminated by the same "strictly ahead of the published revision" gate.
- **No generated-artifact wiring needed:** `src/generated/` does not exist in this repo (confirmed via the GitHub contents API — 404), so there is no per-release pointer snapshot for the post-publish bump to re-freeze; `soldeer-generate-cmd` is correctly omitted.
- **Permissions already sufficient:** the repo's default workflow token permission is `write`, and `package-release.yaml` already calls the reusable with `secrets: inherit` exactly as it did under the old (working) auto-bump model, so the post-publish bump commit + tag push keeps the scope it already had — the lifecycle switch changes only how the version is computed, not the permissions required.

## REQUIRES redeploy at land

No. This changes no deployed bytecode — only the in-dev version string moves.

Co-Authored-By: Claude <noreply@anthropic.com>
