### PR TITLE
chore: match package identity to the rainlang.interface rename

### DIFF
--- a/.github/workflows/package-release.yaml
+++ b/.github/workflows/package-release.yaml
@@ -7,5 +7,5 @@ jobs:
   release:
     uses: rainlanguage/rainix/.github/workflows/rainix-autopublish.yaml@main
     with:
-      soldeer-package: rain-interpreter-interface
+      soldeer-package: rainlang-interface
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rain.interpreter.interface
+# rainlang.interface
 
 ## High level
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 [package]
-name = "rain-interpreter-interface"
-version = "0.1.3"
+name = "rainlang-interface"
+version = "0.2.0"
 
 [profile.default]
 


### PR DESCRIPTION
Refs #105. The GitHub repo was renamed `rain.interpreter.interface` → **`rainlang.interface`**; this makes the repo contents match.

## Changes (3 identity refs + version)

| file | before | after |
|---|---|---|
| `foundry.toml` `[package].name` | `rain-interpreter-interface` | `rainlang-interface` |
| `.github/workflows/package-release.yaml` `soldeer-package` | `rain-interpreter-interface` | `rainlang-interface` |
| `README.md` title | `# rain.interpreter.interface` | `# rainlang.interface` |
| `foundry.toml` `version` | `0.1.3` | `0.2.0` |

Soldeer name follows the established dots→dashes pattern (`raindex.interface` → `raindex-interface`).

## ⚠️ Merging auto-publishes to Soldeer under the new name

`package-release.yaml` runs on push to `main`, so **merging publishes `rainlang-interface@0.2.0`** — a fresh Soldeer package (no prior revisions under this name). I set the debut to **0.2.0** (next minor) per #105's plan; the old `rain-interpreter-interface@0.1.x` revisions stay published for existing consumers. If you'd rather debut at a different version, say so before merge.

## Scope / not in this PR

- No `src/` change — no versioned soldeer self-import references the package by name, so they're unaffected.
- Descriptive prose ("interfaces for the Rainlang interpreter") is accurate and left as-is.
- **Consumer updates** (`rainlang`, `raindex.interface`, `raindex`, `rain.deploy`, downstream) that import the old Soldeer name are **separate follow-ups** — they keep working against the still-published `rain-interpreter-interface@0.1.x` until migrated. That's why this is `Refs` not `Closes` #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)