### PR TITLE
test: pin sourceCount(hex"00") == 0 explicitly

### DIFF
--- a/test/src/lib/bytecode/LibBytecode.sourceCount.t.sol
+++ b/test/src/lib/bytecode/LibBytecode.sourceCount.t.sol
@@ -12,6 +12,13 @@ contract LibBytecodeSourceCountTest is Test {
         assertEq(LibBytecode.sourceCount(""), 0);
     }
 
+    /// The NatSpec documents 0x and 0x00 as equivalent, both having 0 sources.
+    /// `testSourceCount0` pins the empty case; this pins the single 0x00 byte
+    /// explicitly.
+    function testSourceCountSingleZeroByte() external pure {
+        assertEq(LibBytecode.sourceCount(hex"00"), 0);
+    }
+
     /// Test that a non-zero length bytecode returns the first byte as the
     /// source count.
     function testSourceCount1(bytes memory bytecode) external pure {


### PR DESCRIPTION
Closes #115

## Summary

`LibBytecode.sourceCount`'s NatSpec documents that `0x` and `0x00` are equivalent, both having 0 sources. The empty case is pinned by `testSourceCount0`, but the single-byte `hex"00"` case was only covered incidentally by fuzzing (`testSourceCount1` / `testSourceCountReference` include it in their input domain without naming it). This adds the dedicated, deterministic pin the issue asks for:

```solidity
function testSourceCountSingleZeroByte() external pure {
    assertEq(LibBytecode.sourceCount(hex"00"), 0);
}
```

Test-only change; no source or bytecode is touched.

## QA

- **Baseline:** `forge test --mc LibBytecodeSourceCountTest` green on unmutated main-based branch — 4 passed / 0 failed (2048 fuzz runs each for the two fuzz tests).
- **Discriminating test, mutation-validated:** mutating the covered line `count := byte(0, mload(add(bytecode, 0x20)))` → `add(1, byte(...))` fails the new test with `assertion failed: 1 != 0`; restoring the source returns the suite to 4/4 green.
- **Mutation matrix for the unit (whole-suite judgment):**
  - empty → 0: mutant `return 0` → `return 1` killed by existing `testSourceCount0` + `testSourceCountReference` (existing coverage validated).
  - first byte is the count: mutant `add(1, byte(0, …))` killed by the new `testSourceCountSingleZeroByte` and `testSourceCount1`.
  - reads byte 0 specifically: mutant `byte(0, …)` → `byte(1, …)` killed by existing `testSourceCount1` + `testSourceCountReference`.
- **Adversarial pass:** intent derived from the NatSpec oracle (empty → 0; else first byte = count; `0x` ≡ `0x00`; integrity of sources explicitly NOT checked). Implementation matches on all points; the `byte(0, …)` read extracts only the first data byte, which exists for any length ≥ 1, and the differential fuzz against `LibBytecodeSlow.sourceCountSlow` guards the read shape. No candidate bugs; no scope beyond the named gap.
- **Oracle independence:** the expected value (0) comes from the documented equivalence, not from the code's output.
- **Category check:** issue #115 asks for exactly this one named assertion; fully covered, hence `Closes`.
- `forge fmt --check` clean on the changed file.

Co-Authored-By: Claude <noreply@anthropic.com>
